### PR TITLE
Cancel and clear observation task on dynamic service removal

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
@@ -396,6 +396,11 @@ class Scheduler(  # pylint: disable=too-many-instance-attributes, too-many-publi
             del self._inverse_search_mapping[node_uuid]
             self._to_observe.pop(service_name, None)
 
+            service_task = self._service_observation_task.pop(service_name, None)
+
+        if isinstance(service_task, asyncio.Task):
+            await cancel_wait_task(service_task, max_delay=10)
+
         logger.debug("Removed service '%s' from scheduler", service_name)
 
     async def get_stack_status(self, node_uuid: NodeID) -> RunningDynamicServiceDetails:


### PR DESCRIPTION
### Motivation
- Prevent orphaned observation tasks when a dynamic service is removed so background tasks do not continue without scheduler mappings.

### Description
- Updated `Scheduler.remove_service_from_observation` to pop the service's entry from `_service_observation_task` and, if it is an `asyncio.Task`, cancel it via `await cancel_wait_task(service_task, max_delay=10)`.
- Added a focused unit test `test_remove_service_from_observation_cancels_running_observation_task` that creates a running observation task and verifies it is cancelled when removal occurs.
- Touched the existing regression test `test_regression_remove_service_from_observation` to ensure `_service_observation_task` is cleared and added the `asyncio` import required by the new test.

### Testing
- Ran `python -m py_compile` on `services/director-v2/src/.../_scheduler.py` and `services/director-v2/tests/unit/test_modules_dynamic_sidecar_scheduler.py`, which succeeded.
- Attempted to run `cd services/director-v2 && PYENV_VERSION=3.13.8 python -m pytest -q tests/unit/test_modules_dynamic_sidecar_scheduler.py -k "remove_service_from_observation"`, but test collection was blocked by a missing test dependency (`ModuleNotFoundError: No module named 'httpx'`) imported by `tests/conftest.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69946b79595083288019015227db3d20)